### PR TITLE
redefine types

### DIFF
--- a/example/hmatrix3d.jl
+++ b/example/hmatrix3d.jl
@@ -88,7 +88,7 @@ function hmatrix3d_benchmark(N)
     
     @printf("Memory usage: %.2f GiB\n", nnz(hmat)*8/(1024*1024*1024.0))
     @printf("Compression rate: %.2f %%\n", compressionrate(hmat)*100)
-    return stree, hmat
+    return nothing #stree, hmat
 end
 
 

--- a/src/skeletons.jl
+++ b/src/skeletons.jl
@@ -1,4 +1,4 @@
-abstract type MatrixView{T} end
+abstract type MatrixView{F <:Real, I <: Integer} end
 
 import Base.:eltype
 
@@ -23,47 +23,29 @@ function eltype(mv::Adjoint{MT}) where MT <:MatrixView
     return typeof(adjoint(mv)).parameters[1]
 end
 
-mutable struct FullMatrixView{T} <: MatrixView{T}
-    matrix::Matrix{T}
-    rightindices::Vector{Integer}
-    leftindices::Vector{Integer}
-    rowdim::Integer
-    columndim::Integer
+struct FullMatrixView{F,I} <: MatrixView{F,I}
+    matrix::Matrix{F}
+    rightindices::Vector{I}
+    leftindices::Vector{I}
+    rowdim::I
+    columndim::I
 end
 
-mutable struct FullMatrixView2
-    matrix::Matrix{Float64}
-    rightindices::Vector{Int64}
-    leftindices::Vector{Int64}
-    rowdim::Int64
-    columndim::Int64
-end
 
-function FullMatrixView(matrix::Matrix{T}, 
-                        rightindices::Vector{I}, 
-                        leftindices::Vector{I},
-                        rowdim::Integer,
-                        columndim::Integer) where {T, I <: Integer}
+# function FullMatrixView(matrix::Matrix{T}, 
+#                         rightindices::Vector{I}, 
+#                         leftindices::Vector{I},
+#                         rowdim::Integer,
+#                         columndim::Integer) where {T, I <: Integer}
 
-    return FullMatrixView{T}(matrix, 
-                             rightindices, 
-                             leftindices, 
-                             rowdim, 
-                             columndim)
-end
+#     return FullMatrixView{T}(matrix, 
+#                              rightindices, 
+#                              leftindices, 
+#                              rowdim, 
+#                              columndim)
+# end
 
-function FullMatrixView2(matrix::Matrix{Float64}, 
-    rightindices::Vector{I}, 
-    leftindices::Vector{I},
-    rowdim::Integer,
-    columndim::Integer) where {I <: Int64}
 
-return FullMatrixView2(matrix, 
-         rightindices, 
-         leftindices, 
-         rowdim, 
-         columndim)
-end
 
 import Base.:*
 function *(fmv::FMT, vecin::VT) where {FMT <:FullMatrixView, VT <: AbstractVector}
@@ -86,29 +68,30 @@ function nnz(fmv::FullMatrixView)
     return size(fmv.matrix,1)*size(fmv.matrix,2)
 end
 
-mutable struct LowRankMatrixView{T} <: MatrixView{T}
-    rightmatrix::Matrix{T}
-    leftmatrix::Matrix{T}
-    rightindices::Vector{Integer}
-    leftindices::Vector{Integer}
-    rowdim::Integer
-    columndim::Integer
+struct LowRankMatrixView{F,I} <: MatrixView{F,I}
+    rightmatrix::Matrix{F}
+    leftmatrix::Matrix{F}
+    rightindices::Vector{I}
+    leftindices::Vector{I}
+    rowdim::I
+    columndim::I
 end
 
-function LowRankMatrixView(rightmatrix::Matrix{T}, 
-                            leftmatrix::Matrix{T}, 
-                            rightindices::Vector{I},
-                            leftindices::Vector{I},
-                            rowdim::Integer,
-                            columndim::Integer) where {T, I <: Integer}
 
-    return LowRankMatrixView{T}(rightmatrix,
-                                leftmatrix,
-                                rightindices, 
-                                leftindices, 
-                                rowdim, 
-                                columndim)
-end
+# function LowRankMatrixView(rightmatrix::Matrix{T}, 
+#                             leftmatrix::Matrix{T}, 
+#                             rightindices::Vector{I},
+#                             leftindices::Vector{I},
+#                             rowdim::Integer,
+#                             columndim::Integer) where {T, I <: Integer}
+
+#     return LowRankMatrixView{T}(rightmatrix,
+#                                 leftmatrix,
+#                                 rightindices, 
+#                                 leftindices, 
+#                                 rowdim, 
+#                                 columndim)
+# end
 
 function *(lmv::LMT, vecin::VT) where {LMT <:LowRankMatrixView, VT <: AbstractVector}
     T = promote_type(eltype(lmv), eltype(vecin))


### PR DESCRIPTION
now I get (in the console):

julia> hmatrix3d_benchmark(20000)
  5.798143 seconds (23.42 M allocations: 2.279 GiB, 7.76% gc time)
  5.798642 seconds (23.42 M allocations: 2.279 GiB, 7.76% gc time)
Memory usage: 0.91 GiB
Compression rate: 69.55 %

julia> hmatrix3d_benchmark(40000)
 16.272754 seconds (142.04 M allocations: 10.082 GiB, 8.42% gc time)
 16.274403 seconds (142.09 M allocations: 10.086 GiB, 8.41% gc time)
Memory usage: 1.54 GiB
Compression rate: 87.10 %

julia> hmatrix3d_benchmark(80000)
 38.477922 seconds (287.25 M allocations: 21.158 GiB, 7.62% gc time)
 38.482266 seconds (287.31 M allocations: 21.162 GiB, 7.62% gc time)
Memory usage: 4.11 GiB
Compression rate: 91.37 %

julia> hmatrix3d_benchmark(160000)
133.854010 seconds (582.87 M allocations: 46.379 GiB, 17.38% gc time)
133.856274 seconds (582.93 M allocations: 46.383 GiB, 17.38% gc time)
Memory usage: 12.21 GiB
Compression rate: 93.60 %