### PR TITLE
Bug fixes on unit tests

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -22,6 +22,7 @@ ProfileView = "c46f51b8-102a-5cf2-8d2c-8597cb0e0da7"
 ProgressMeter = "92933f4c-e287-5a05-a399-4b506db050ca"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
+TestItemRunner = "f8b46487-2199-4994-9208-9a1283c18c0a"
 TestItems = "1c621080-faea-4a02-84b6-bbd5e436b8fe"
 
 [compat]

--- a/test/test_fmmbases.jl
+++ b/test/test_fmmbases.jl
@@ -36,7 +36,8 @@ yX1 = fmmassemble(
     S,
     X1,
     X1,
-    multithreading=true
+    multithreading=true,
+    treeoptions=BoxTreeOptions(nmin=20),
 ) * xX1
 
 yXd0 = fmmassemble(


### PR DESCRIPTION
BEAST.jl has to be modified for handling `gamma=Nothing`. Unit tests failed due to very small `nmin` values in the FMM. `nmin` sets the number of fullrank blocks that are not handled by the FMM. A larger default value could be an option on the long run.