### PR TITLE
Modifiacations towards a flexible ACA

### DIFF
--- a/src/FastBEAST.jl
+++ b/src/FastBEAST.jl
@@ -2,7 +2,9 @@ module FastBEAST
 using LinearAlgebra
 include("tree/tree.jl")
 
+include("aca/aca_utils.jl")
 include("aca/pivoting.jl")
+include("aca/convergence.jl")
 include("aca/aca.jl")
 include("skeletons.jl")
 include("hmatrix.jl")

--- a/src/aca/aca_utils.jl
+++ b/src/aca/aca_utils.jl
@@ -1,0 +1,74 @@
+struct LazyMatrix{I, F} <: AbstractMatrix{F}
+    μ::Function
+    τ::Vector{I}
+    σ::Vector{I}
+end
+
+Base.size(A::LazyMatrix) = (length(A.τ), length(A.σ))
+
+function Base.getindex(
+    A::T,
+    I,
+    J
+) where {K, F, T <: LazyMatrix{K, F}}
+
+    Z = zeros(F, length(I), length(J))
+    A.μ(Z, view(A.τ, I), view(A.σ, J))
+    return Z
+end
+
+""" 
+    function LazyMatrix(μ::Function, τ::Vector{I}, σ::Vector{I}, ::Type{F}) where {I, F}
+
+# Arguments 
+- `μ::Function`: 
+- `τ::Vector{I}`: 
+- `σ::Vector{I}`: 
+- `::Type{F}`: 
+
+"""
+function LazyMatrix(μ::Function, τ::Vector{I}, σ::Vector{I}, ::Type{F}) where {I, F}
+    
+    return LazyMatrix{I, F}(μ, τ, σ)
+end
+
+@views function (A::LazyMatrix{K, F})(Z::S, I, J) where {K, F, S <: AbstractMatrix{F}}
+
+    A.μ(view(Z, I, J), view(A.τ, I), view(A.σ, J))
+end
+
+mutable struct ACAGlobalMemory{I, F, K}
+    Ic::I
+    Jc::I
+    U::Matrix{K}
+    V::Matrix{K}
+    used_I::Vector{Bool}
+    used_J::Vector{Bool}
+    normUV::F
+end
+
+maxrank(acamemory::ACAGlobalMemory) = size(acamemory.U, 2)
+
+""" 
+    function allocate_aca_memory(::Type{F}, maxrows, maxcolumns; maxrank=40) where {F}
+
+Preallocation of sorage for the ACA.
+
+# Arguments 
+- `::Type{F}`: Type of matrix entries.
+- `maxrows`: Number of rows.
+- `maxcolumns`: Number of columns.
+
+# Optional Arguments 
+- `maxrank=40`: Maximum rank for the ACA. The ACA stops of more rows/columns are used for
+the approximation.
+
+"""
+function allocate_aca_memory(::Type{F}, maxrows, maxcolumns; maxrank=40) where {F}
+
+    U = zeros(F, maxrows, maxrank)
+    V = zeros(F, maxrank, maxcolumns)
+    used_I = zeros(Bool, maxrows)
+    used_J = zeros(Bool, maxcolumns)
+    return ACAGlobalMemory(1, 1, U, V, used_I, used_J, 0.0)
+end

--- a/src/aca/convergence.jl
+++ b/src/aca/convergence.jl
@@ -1,0 +1,295 @@
+abstract type ConvergenceCriterion end
+
+struct Standard <: ConvergenceCriterion end
+
+""" 
+    function initconvergence!(
+        M::FastBEAST.LazyMatrix{I, K}, 
+        convergcrit::Standard
+    ) where {I, K} end
+
+# Arguments 
+- `M::FastBEAST.LazyMatrix{I, K}`: Assembler matrix used to compute rows and columns. 
+- `convergcrit::Standard`: Convergence criterion used in the ACA, here used for dispaching. 
+
+"""
+function initconvergence!(
+    M::FastBEAST.LazyMatrix{I, K}, 
+    convergcrit::Standard
+) where {I, K} end
+
+mutable struct RandomSampling{I, K} <: ConvergenceCriterion
+    nsamples::I
+    indices::Matrix{I}
+    rest::Matrix{K}
+end
+
+""" 
+    function RandomSampling(::Type{K}; nsamples=0) where K
+
+Cunstructor for random-sampling convergence criterion. 
+
+# Arguments 
+- `::Type{K}`: Type of matrix entries.
+
+# Optional Arguments 
+- `nsamples=0`: Number of random samples used for the approximation. If not changed it will 
+be number of rows + number of columns.
+
+"""
+function RandomSampling(::Type{K}; nsamples=0) where K
+    return RandomSampling(nsamples, zeros(Int, nsamples, 2), zeros(K, nsamples, 1))
+end
+
+mutable struct Combined{I, K} <: ConvergenceCriterion
+    nsamples::I
+    indices::Matrix{I}
+    rest::Matrix{K}
+end
+
+""" 
+    function Combined(::Type{K}; nsamples=0) where K
+
+Cunstructor for combined convergence criterion (random sampling and standard). 
+
+# Arguments 
+- `::Type{K}`: Type of matrix entries.
+
+# Optional Arguments 
+- `nsamples=0`: Number of random samples used for the approximation. If not changed it will 
+be number of rows + number of columns.
+
+"""
+function Combined(::Type{K}; nsamples=0) where K
+    return Combined(nsamples, zeros(Int, nsamples, 2), zeros(K, nsamples, 1))
+end
+
+""" 
+    function initconvergence!(
+        M::FastBEAST.LazyMatrix{I, K},
+        convergcrit::Union{RandomSampling{I, K}, Combined{I, K}}
+    ) where {I, K}
+
+Setup of the convergence criterion. Computation of the random samples, and allocation 
+of the storage if not happened yet. 
+
+# Arguments 
+- `M::FastBEAST.LazyMatrix{I, K}`: Assembler matrix used to compute rows and columns.
+- `convergcrit::Union{RandomSampling{I, K}, Combined{I, K}}`: Convergence criterion 
+used in the ACA, here used for dispaching.
+
+"""
+function initconvergence!(
+    M::FastBEAST.LazyMatrix{I, K},
+    convergcrit::Union{RandomSampling{I, K}, Combined{I, K}}
+) where {I, K}
+
+    if convergcrit.nsamples == 0
+        convergcrit.nsamples = size(M)[1] + size(M)[2]
+        convergcrit.indices = zeros(Int, convergcrit.nsamples, 2)
+        convergcrit.rest = zeros(K, convergcrit.nsamples, 1)
+    end
+
+    convergcrit.indices[1:convergcrit.nsamples, 1] = 
+        rand(1:length(M.τ), convergcrit.nsamples)
+    convergcrit.indices[1:convergcrit.nsamples, 2] = 
+        rand(1:length(M.σ), convergcrit.nsamples)
+    
+    for ind in eachindex(convergcrit.rest)
+        @views M.μ(
+            convergcrit.rest[ind:ind, 1:1], 
+            M.τ[convergcrit.indices[ind, 1]:convergcrit.indices[ind, 1]],
+            M.σ[convergcrit.indices[ind, 2]:convergcrit.indices[ind, 2]]
+        )
+    end
+end
+
+""" 
+    function checkconvergence(
+        normU::F,
+        normV::F,
+        maxrows::I,
+        maxcolumns::I,
+        am::ACAGlobalMemory{I, F, K},
+        rowpivstrat::PivStrat,
+        columnpivstrat::PivStrat,
+        convergcrit::Standard,
+        tol::F
+    ) where {I, F, K}
+
+Checks if convergence in the ACA is reached using the standard criterion.
+
+# Arguments 
+- `normU::F`: Norm of last column.
+- `normV::F`: Norm of last row.
+- `maxrows::I`: Number of rows.
+- `maxcolumns::I`: Number of columns.
+- `am::ACAGlobalMemory{I, F, K}`: Preallocated memory used for the ACA. 
+- `rowpivstrat::PivStrat`: Pivoting strategy for the rows.
+- `columnpivstrat::PivStrat`: Pivoting strategy for the rows.
+- `convergcrit::Standard`: Convergence criterion.
+- `tol::F`: Tolerance of the ACA. 
+
+"""
+function checkconvergence(
+    normU::F,
+    normV::F,
+    maxrows::I,
+    maxcolumns::I,
+    am::ACAGlobalMemory{I, F, K},
+    rowpivstrat::PivStrat,
+    columnpivstrat::PivStrat,
+    convergcrit::Standard,
+    tol::F
+) where {I, F, K}
+
+    if normU == 0 || normV == 0
+        am.Ic -= 1 
+        rowpivstrat = FastBEAST.MaxPivoting()
+        
+        return false, rowpivstrat, columnpivstrat
+    else
+        am.normUV += (normU * normV)^2
+        for j = 1:(am.Jc-1)
+            @views am.normUV += 2*abs.(dot(am.U[1:maxrows, am.Jc], am.U[1:maxrows, j]) * dot(
+                am.V[am.Ic, 1:maxcolumns],
+                am.V[j, 1:maxcolumns])
+            )
+        end
+
+        return normU*normV <= tol*sqrt(am.normUV), rowpivstrat, columnpivstrat
+    end
+end
+
+""" 
+    function checkconvergence(
+        normU::F,
+        normV::F,
+        maxrows::I,
+        maxcolumns::I,
+        am::ACAGlobalMemory{I, F, K},
+        rowpivstrat::PivStrat,
+        columnpivstrat::PivStrat,
+        convergcrit::Combined{I, K},
+        tol::F,
+    ) where {I, F, K}
+
+Checks if convergence in the ACA is reached using the combined criterion.
+
+# Arguments 
+- `normU::F`: Norm of last column.
+- `normV::F`: Norm of last row.
+- `maxrows::I`: Number of rows.
+- `maxcolumns::I`: Number of columns.
+- `am::ACAGlobalMemory{I, F, K}`: Preallocated memory used for the ACA. 
+- `rowpivstrat::PivStrat`: Pivoting strategy for the rows.
+- `columnpivstrat::PivStrat`: Pivoting strategy for the rows.
+- `convergcrit::Combined{I, K}`: Convergence criterion.
+- `tol::F`: Tolerance of the ACA.
+
+"""
+function checkconvergence(
+    normU::F,
+    normV::F,
+    maxrows::I,
+    maxcolumns::I,
+    am::ACAGlobalMemory{I, F, K},
+    rowpivstrat::PivStrat,
+    columnpivstrat::PivStrat,
+    convergcrit::Combined{I, K},
+    tol::F
+) where {I, F, K}
+
+    if normU == 0 || normV == 0
+        rowpivstrat = FastBEAST.MaxPivoting()
+        
+        return false, rowpivstrat, columnpivstrat
+    else
+        # standard convergence
+        am.normUV += (normU * normV)^2
+        for j = 1:(am.Jc-1)
+            @views am.normUV += 2*real(dot(am.U[1:maxrows, am.Jc], am.U[1:maxrows, j]) * dot(
+                am.V[am.Ic, 1:maxcolumns],
+                am.V[j, 1:maxcolumns])
+            )
+        end
+        
+        # random sampling convergence
+        for i in eachindex(convergcrit.rest)
+            @views convergcrit.rest[i] -= 
+                am.U[convergcrit.indices[i, 1], am.Jc] * am.V[am.Ic, convergcrit.indices[i, 2]] 
+        end
+
+        meanrest = sum(abs.(convergcrit.rest).^2)/length(convergcrit.rest)
+        conv = (sqrt(meanrest*maxrows*maxcolumns) <= tol*sqrt(am.normUV) && 
+            normU*normV <= tol*sqrt(am.normUV))
+
+        return conv, rowpivstrat, columnpivstrat
+    end
+end
+
+""" 
+    function checkconvergence(
+        normU::F,
+        normV::F,
+        maxrows::I,
+        maxcolumns::I,
+        am::ACAGlobalMemory{I, F, K},
+        rowpivstrat::PivStrat,
+        columnpivstrat::PivStrat,
+        convergcrit::RandomSampling{I, K},
+        tol::F,
+    ) where {I, F, K}
+
+Checks if convergence in the ACA is reached using the random-sampling criterion.
+
+# Arguments 
+- `normU::F`: Norm of last column.
+- `normV::F`: Norm of last row.
+- `maxrows::I`: Number of rows.
+- `maxcolumns::I`: Number of columns.
+- `am::ACAGlobalMemory{I, F, K}`: Preallocated memory used for the ACA. 
+- `rowpivstrat::PivStrat`: Pivoting strategy for the rows.
+- `columnpivstrat::PivStrat`: Pivoting strategy for the rows.
+- `convergcrit::RandomSampling{I, K}`: Convergence criterion.
+- `tol::F`: Tolerance of the ACA.
+
+"""
+function checkconvergence(
+    normU::F,
+    normV::F,
+    maxrows::I,
+    maxcolumns::I,
+    am::ACAGlobalMemory{I, F, K},
+    rowpivstrat::PivStrat,
+    columnpivstrat::PivStrat,
+    convergcrit::RandomSampling{I, K},
+    tol::F
+) where {I, F, K}
+
+    if normU == 0 || normV == 0
+        rowpivstrat = FastBEAST.MaxPivoting()
+        
+        return false, rowpivstrat, columnpivstrat
+    else
+        # standard convergence
+        am.normUV += (normU * normV)^2
+        for j = 1:(am.Jc-1)
+            @views am.normUV += 2*real(dot(am.U[1:maxrows, am.Jc], am.U[1:maxrows, j]) * dot(
+                am.V[am.Ic, 1:maxcolumns],
+                am.V[j, 1:maxcolumns])
+            )
+        end
+        
+        # random sampling convergence
+        for i in eachindex(convergcrit.rest)
+            @views convergcrit.rest[i] -= 
+                am.U[convergcrit.indices[i, 1], am.Jc] * am.V[am.Ic, convergcrit.indices[i, 2]] 
+        end
+
+        meanrest = sum(abs.(convergcrit.rest).^2)/length(convergcrit.rest)
+        conv = sqrt(meanrest*maxrows*maxcolumns) <= tol*sqrt(am.normUV)
+
+        return conv, rowpivstrat, columnpivstrat
+    end
+end

--- a/src/aca/pivoting.jl
+++ b/src/aca/pivoting.jl
@@ -11,17 +11,45 @@ function MaxPivoting()
     return MaxPivoting(1)
 end
 
+""" 
+    function firstindex(strat::MaxPivoting{I}, totalindices) where I
+
+Returns first index of the pivoting strategy. For `MaxPivoting` this will be 1 
+if not defined.
+
+# Arguments 
+- `strat::MaxPivoting{I}`: Pivoting strategy.
+- `totalindices`: Indices corresponding to the matrix block, here not used.
+
+"""
 function firstindex(strat::MaxPivoting{I}, totalindices) where I
     return strat, strat.firstindex
 end
 
+""" 
+    function pivoting(
+        strat::MaxPivoting{I},
+        roworcolumn,
+        acausedindices,
+        totalindices
+    ) where {I}
+
+Returns next row or column used for approximation.
+
+# Arguments 
+- `strat::MaxPivoting{I}`: Pivoting strategy. 
+- `roworcolumn`: Last row or column.
+- `acausedindices`: Already used indices. Rows/colums can be used only once.
+- `totalindices`: All indices corresponding to the matrix block
+
+"""
 function pivoting(
     strat::MaxPivoting{I},
     roworcolumn,
     acausedindices,
     totalindices
 ) where {I}
-    
+
     if maximum(roworcolumn) != 0 
         return argmax(roworcolumn .* (.!acausedindices))
     else 
@@ -35,25 +63,46 @@ struct FillDistance{I, F} <: PivStrat
     dist::Vector{F}
 end
 
+""" 
+    function FillDistance(loc::Vector{SVector{I, F}}) where {I, F}
+
+Cunstructor of fill-distance pivoting strategy.
+
+# Arguments 
+- `loc::Vector{SVector{I, F}}`: Geometric positions of basis functions
+
+"""
 function FillDistance(loc::Vector{SVector{I, F}}) where {I, F}
 
     return FillDistance(loc, zeros(F, length(loc)))
 end
 
+""" 
+    function firstindex(strat::FillDistance{I, F}, globalindices) where {I, F}
+
+Returns first index of the pivoting strategy. For `FillDistance` this will be the 
+basis function closest to the center of the distribution.
+
+# Arguments 
+- `strat::FillDistance{I, F}`: Pivoting strategy.
+- `totalindices`: Indices corresponding to the matrix block, used to determine the
+basis functions/positions used for pivoting.
+
+"""
 function firstindex(strat::FillDistance{I, F}, globalindices) where {I, F}
-    
+
     nglobalindices = length(globalindices)
     distances = zeros(F, nglobalindices)
     dist = zeros(Float64, nglobalindices)
-    
+
     firstlocalindex = 1
-    
+
     for l = 1:nglobalindices
         dist[l] = norm(
             strat.loc[globalindices[l]] - strat.loc[globalindices[firstlocalindex]]
         )
     end
-    
+
     maxdist = maximum(dist)
 
     for l = 2:nglobalindices
@@ -79,6 +128,23 @@ function firstindex(strat::FillDistance{I, F}, globalindices) where {I, F}
     return FillDistance(strat.loc[globalindices], dist), firstlocalindex
 end
 
+""" 
+    function pivoting(
+        strat::FillDistance{I, F},
+        roworcolumn,
+        acausedindices,
+        totalindices
+    ) where {I, F}
+
+Returns next row or column used for approximation.
+
+# Arguments 
+- `strat::FillDistance{I, F}`: Pivoting strategy. 
+- `roworcolumn`: Last row or column.
+- `acausedindices`: Already used indices. Rows/colums can be used only once.
+- `totalindices`: All indices corresponding to the matrix block
+
+"""
 function pivoting(
     strat::FillDistance{I, F},
     roworcolumn,
@@ -108,13 +174,34 @@ struct TrueFillDistance{I, F} <: PivStrat
     dist::Vector{F}
 end
 
+""" 
+    function TrueFillDistance(loc::Vector{SVector{I, F}}) where {I, F}
+
+Cunstructor of fill-distance pivoting strategy.
+
+# Arguments 
+- `loc::Vector{SVector{I, F}}`: Geometric positions of basis functions
+
+"""
 function TrueFillDistance(loc::Vector{SVector{I, F}}) where {I, F}
 
     return TrueFillDistance(loc, zeros(F, length(loc)))
 end
 
+""" 
+    function firstindex(strat::TrueFillDistance{I, F}, globalindices) where {I, F}
+
+Returns first index of the pivoting strategy. For `TrueFillDistance` this will be the 
+basis function closest to the center of the distribution.
+
+# Arguments 
+- `strat::TrueFillDistance{I, F}`: Pivoting strategy.
+- `totalindices`: Indices corresponding to the matrix block, used to determine the
+basis functions/positions used for pivoting. 
+
+"""
 function firstindex(strat::TrueFillDistance{I, F}, globalindices) where {I, F}
-    
+
     nglobalindices = length(globalindices)
     distances = zeros(F, nglobalindices)
     dist = zeros(Float64, nglobalindices)
@@ -152,6 +239,23 @@ function firstindex(strat::TrueFillDistance{I, F}, globalindices) where {I, F}
     return TrueFillDistance(strat.loc[globalindices], dist), firstlocalindex
 end
 
+""" 
+    function pivoting(
+        strat::TrueFillDistance{I, F},
+        roworcolumn,
+        acausedindices,
+        totalindices
+    ) where {I, F}
+
+Returns next row or column used for approximation.
+
+# Arguments 
+- `strat::TrueFillDistance{I, F}`: Pivoting strategy. 
+- `roworcolumn`: Last row or column.
+- `acausedindices`: Already used indices. Rows/colums can be used only once.
+- `totalindices`: All indices corresponding to the matrix block
+
+"""
 function pivoting(
     strat::TrueFillDistance{I, F},
     roworcolumn,


### PR DESCRIPTION
The ACA did not allow different convergence criteria yet. The default criterion is still the stadard one following Zhao. Additionally I included a random sampling and a combined criterion. Further criteria can be included following the scheme given in the convergence.jl script.

Beside these modifications I included in the H-Matrix part a check for ineffective approximations. If the ACA uses to many rows and columns, the H-Matrix computes the full matrix block and neglects the approximation.