### PR TITLE
Rework of the ACA algorithm

### DIFF
--- a/src/hmatrix.jl
+++ b/src/hmatrix.jl
@@ -515,7 +515,7 @@ function getcompressedmatrix(
             am;
             rowpivstrat=compressor.rowpivstrat,
             columnpivstrat=compressor.columnpivstrat,
-            convergcrit=compressor.convergcrit,
+            convcrit=compressor.convcrit,
             tol=compressor.tol,
             svdrecompress=compressor.svdrecompress
         )

--- a/test/test_aca.jl
+++ b/test/test_aca.jl
@@ -245,7 +245,7 @@ lm = LazyMatrix(fct, Vector(1:size(A, 1)), Vector(1:size(A, 2)), Float64)
 
 U, V = aca(
     lm,
-    convergcrit=FastBEAST.Combined(Float64),
+    convcrit=FastBEAST.Combined(Float64),
     maxrank=200,
     svdrecompress=false
 )

--- a/test/test_beast.jl
+++ b/test/test_beast.jl
@@ -40,21 +40,21 @@ end
 
 mat, hmat_single = test_beast_laplace_singlelayer(0.1) 
 
-@test nnz(hmat_single) == 3957191
+@test nnz(hmat_single) == 3902035
 
 @test compressionrate(hmat_single) > 0.3
 @test estimate_reldifference(hmat_single, mat) ≈ 0 atol=1e-4
 
 mat, hmat_multi = test_beast_laplace_singlelayer(0.1, multithreading=true) 
 
-@test nnz(hmat_multi) == 3957191
+@test nnz(hmat_multi) == 3902035
 
 @test compressionrate(hmat_multi) > 0.3
 @test estimate_reldifference(hmat_multi, mat) ≈ 0 atol=1e-4
 
 mat, hmat_single = test_beast_laplace_singlelayer(0.1, quadstrat=BEAST.DoubleNumQStrat(1, 1)) 
 
-@test nnz(hmat_single) == 3957191
+@test nnz(hmat_single) == 3902035
 
 @test compressionrate(hmat_single) > 0.3
 @test estimate_reldifference(hmat_single, mat) ≈ 0 atol=1e-3
@@ -65,7 +65,7 @@ mat, hmat_multi = test_beast_laplace_singlelayer(
     quadstrat=BEAST.DoubleNumQStrat(1, 1)
 ) 
 
-@test nnz(hmat_multi) == 3957191
+@test nnz(hmat_multi) == 3902035
 
 @test compressionrate(hmat_multi) > 0.3
 @test estimate_reldifference(hmat_multi, mat) ≈ 0 atol=1e-3
@@ -77,7 +77,7 @@ mat, hmat_svdmulti = test_beast_laplace_singlelayer(
     svdrecompress=true
 ) 
 
-@test nnz(hmat_svdmulti) == 3957191
+@test nnz(hmat_svdmulti) == 3902035
 
 @test compressionrate(hmat_svdmulti) > 0.3
 @test estimate_reldifference(hmat_svdmulti, mat) ≈ 0 atol=1e-3


### PR DESCRIPTION
I reworked the ACA towards a more flexible implementation.

I renamed the `TrueFillDistance` to `FillDistance` and introduced an abstract type `FD` that concludes all fill-distance based strategies. This allows to reduce code repetition.
Additionally I included the `MRFPivoting` strategy.

As convergence criteria the `Standard` criterion, a `Random Sampling`, and a `Combined` criterion are available.

The modifications in the `test_beast.jl` shows that the compression of matrix blocks becomes more efficient due to better handling of special cases such as zero rows or similar.